### PR TITLE
adds dockerfile and updated readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,72 @@
+
+
+FROM --platform=linux/amd64 ubuntu:20.04
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+
+ARG LIBFABRIC_VERSION=1.18.1
+
+# Install required packages and dependencies
+RUN   apt -y update \
+      && apt -y install build-essential wget doxygen gnupg gnupg2 curl apt-transport-https software-properties-common libgl1  \
+ git vim gfortran libtool python3-venv ninja-build python3-pip \
+      libnuma-dev python3-dev \
+      && apt -y remove --purge --auto-remove cmake \
+      && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null\
+ | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+      && apt-add-repository -y "deb https://apt.kitware.com/ubuntu/ jammy-rc main" \
+      && apt -y update 
+
+# Build and install libfabric
+RUN (if [ -e /tmp/build ]; then rm -rf /tmp/build; fi;) \
+      && mkdir -p /tmp/build \
+      && cd /tmp/build \
+      && wget https://github.com/ofiwg/libfabric/archive/refs/tags/v${LIBFABRIC_VERSION}.tar.gz \
+      && tar xf v${LIBFABRIC_VERSION}.tar.gz \
+      && cd libfabric-${LIBFABRIC_VERSION} \ 
+      && ./autogen.sh \
+      && ./configure \
+      && make -j 16 \ 
+      && make install
+
+ARG SPHAE_VERSION=1.4.4
+
+#
+# Install miniforge
+#
+RUN set -eux ; \
+  curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh ; \
+  bash ./Miniforge3-* -b -p /opt/miniforge3 -s ; \
+  rm -rf ./Miniforge3-*
+ENV PATH /opt/miniforge3/bin:$PATH
+#
+# Install conda environment
+# 
+RUN set -eux ; \
+  mamba install -y -c conda-forge -c bioconda -c defaults \
+  sphae=${SPHAE_VERSION}=pyhdfd78af_0 python==3.11 
+ENV PATH /opt/miniforge3/bin:$PATH
+RUN conda clean -af -y
+
+
+# install databases - needed or else sphae won't run - makes the container huge but nothing we can really do
+RUN sphae install --threads 8 --conda-frontend mamba 
+
+# for weird filtlong bug https://github.com/potree/PotreeConverter/issues/281
+ENV LC_ALL=C
+ENV LANGUAGE=
+
+# download test data
+RUN git clone "https://github.com/linsalrob/sphae.git"
+
+# run with --conda-create-envs-only to create all required conda envs (without running itself for speedup)
+RUN sphae run --threads 8 --input sphae/tests/data/illumina-subset --output example -k --conda-frontend mamba --conda-create-envs-only
+RUN sphae run --threads 8 --input sphae/tests/data/nanopore-subset --sequencing longread --output examplelr -k --conda-frontend mamba --conda-create-envs-only
+
+# cleanup
+RUN rm -rf example
+RUN rm -rf examplelr
+
+
+

--- a/README.md
+++ b/README.md
@@ -83,6 +83,24 @@ pip install -e .
 #confirm the workflow is installed by running the below command 
 sphae --help
 ```
+**Container Install**
+
+You can use the pre-built sphae container with Docker/Singularity/apptainer available [here](https://quay.io/repository/gbouras13/sphae). It is very large as it comes with all the required software pre-installed, so may take a while to download and install.
+
+As an example of installing the sphae .sif file and running sphae v1.4.4  with Singularity:
+
+```
+TMPDIR=<where your tmpdir lives>
+IMAGEDIR-<where you want the image to live>
+
+singularity pull --tmpdir=$TMPDIR  --dir $IMAGEDIR docker://quay.io/gbouras13/sphae:1.4.4
+singularity exec  sphae_1.4.4.sif sphae --help 
+singularity exec  sphae_1.4.4.sif sphae run --help
+singularity exec  sphae_1.4.4.sif sphae install --help 
+```
+
+You will still need to install the databases with `sphae install` as outlined below.
+
 
 ## Installing databases
 Run the below command,


### PR DESCRIPTION
Adds dockerfile and some documentation for the pre-built sphae container.

As discussed, should implement a new subcommand just touching a series of files to make all the conda envs without requiring DB installation (`--install-conda-envs-only` doesn't work as the viral-verify needs the DB), as this will make the container smaller. But it works!
